### PR TITLE
管理画面に価格入力欄を追加

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -14,6 +14,7 @@
     <div id="admin-form">
       <input type="text" id="menu-name" placeholder="メニュー名">
       <input type="date" id="menu-date">
+      <input type="number" id="menu-price" placeholder="価格（円）">
       <button id="add-menu-btn">メニュー追加</button>
     </div>
 

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -17,7 +17,7 @@ function displayMenusAdmin() {
   menus.forEach(menu => {
     const menuDiv = document.createElement('div');
     menuDiv.className = 'menu-item';
-    menuDiv.textContent = `${menu.name}（${menu.date}）`;
+    menuDiv.textContent = `${menu.name}（${menu.date}）（${menu.price ? menu.price + '円）' : '価格未設定）'}`;
     menuList.appendChild(menuDiv);
   });
 }
@@ -26,6 +26,7 @@ function displayMenusAdmin() {
 document.getElementById('add-menu-btn').onclick = () => {
   const menuName = document.getElementById('menu-name').value;
   const menuDate = document.getElementById('menu-date').value;
+  const menuPrice = document.getElementById('menu-price').value;
 
   if (menuName && menuDate) {
     const menus = getMenus();
@@ -33,6 +34,7 @@ document.getElementById('add-menu-btn').onclick = () => {
       id: Date.now().toString(),
       name: menuName,
       date: menuDate,
+      price: menuPrice
     });
 
     saveMenus(menus);
@@ -41,6 +43,7 @@ document.getElementById('add-menu-btn').onclick = () => {
     // 入力欄クリア
     document.getElementById('menu-name').value = '';
     document.getElementById('menu-date').value = '';
+    document.getElementById('menu-price').value = '';
 
     alert('メニューが追加されました！');
   } else {

--- a/style.css
+++ b/style.css
@@ -50,7 +50,8 @@ h1 {
 }
 
 #admin-form input[type="text"],
-#admin-form input[type="date"] {
+#admin-form input[type="date"],
+#admin-form input[type="number"] {
   padding: 10px;
   width: 200px;
   border: 2px solid #ff6f00;


### PR DESCRIPTION
## 背景・概要

- Issues: https://github.com/kotomi1338/gakushoku-menu-app-20250722/issues/1

今は「メニュー名」と「日付」しか保存できない状態です。

しかし、実際の学食メニューには「価格」も表示してほしいので、
登録時に「価格」も一緒に保存できるように機能追加を行います。


## 実装したこと
- [x] `admin.html` に「価格」用の入力欄を追加する
- [x] `admin.js` で入力された価格情報も一緒に保存できるようにする
- [x] 保存された価格情報がLocalStorageに反映されることを確認する
